### PR TITLE
feat: Implement chat auto-reply feature

### DIFF
--- a/API.md
+++ b/API.md
@@ -705,6 +705,64 @@ curl -s -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data 
 
 ---
 
+### Add/Update Auto-Reply
+* **Method:** `POST`
+* **Path:** `/chat/autoreply`
+* **Description:** Sets up an auto-reply for a specific phone number. If an auto-reply for the given phone number already exists for the user, it will be updated. If not, a new one will be created.
+* **Authentication:** Requires user token.
+* **Request Body (JSON):**
+  ```json
+  {
+    "Phone": "1234567890", // Target phone number (normalized, e.g., digits only or international format used by the system)
+    "Body": "Hello! I am currently unavailable and will get back to you soon."
+  }
+  ```
+* **Responses:**
+  * `201 Created`: If a new auto-reply was successfully created.
+    ```json
+    {
+      "code": 201,
+      "data": {
+        "detail": "Auto-reply added successfully",
+        "id": "generated-unique-id-for-the-rule"
+      },
+      "success": true
+    }
+    ```
+  * `400 Bad Request`: If `Phone` or `Body` is missing or invalid.
+  * `409 Conflict`: If an auto-reply for this phone number already exists for the user.
+  * `500 Internal Server Error`: For other server-side errors.
+
+---
+
+### Delete Auto-Reply
+* **Method:** `DELETE`
+* **Path:** `/chat/autoreply`
+* **Description:** Deletes an existing auto-reply for a specific phone number for the authenticated user.
+* **Authentication:** Requires user token.
+* **Request Body (JSON):**
+  ```json
+  {
+    "Phone": "1234567890" // Target phone number whose auto-reply rule should be deleted.
+  }
+  ```
+* **Responses:**
+  * `200 OK`: If the auto-reply was successfully deleted.
+    ```json
+    {
+      "code": 200,
+      "data": {
+        "detail": "Auto-reply deleted successfully"
+      },
+      "success": true
+    }
+    ```
+  * `400 Bad Request`: If `Phone` is missing or invalid.
+  * `404 Not Found`: If no auto-reply rule exists for the given phone number for this user.
+  * `500 Internal Server Error`: For other server-side errors.
+
+---
+
 ## Download Document
 
 Downloads a Document from a message and retrieves it Base64 media encoded. Required request parameters are: Url, MediaKey, Mimetype, FileSHA256 and FileLength

--- a/main.go
+++ b/main.go
@@ -14,6 +14,11 @@ import (
 	"syscall"
 	"time"
 
+	"database/sql" // Added for sql.ErrNoRows
+	"go.mau.fi/whatsmeow" // Added for whatsmeow.SendRequestExtra
+	"go.mau.fi/whatsmeow/proto/waE2E" // Added for waE2E.Message
+	"google.golang.org/protobuf/proto" // Added for proto.String
+
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	waLog "go.mau.fi/whatsmeow/util/log"
 

--- a/routes.go
+++ b/routes.go
@@ -101,6 +101,9 @@ func (s *server) routes() {
 	s.router.Handle("/chat/send/poll", c.Then(s.SendPoll())).Methods("POST")
 	s.router.Handle("/chat/send/edit", c.Then(s.SendEditMessage())).Methods("POST")
 
+	s.router.Handle("/chat/autoreply", c.Then(s.AddAutoReply())).Methods("POST")
+	s.router.Handle("/chat/autoreply", c.Then(s.DeleteAutoReply())).Methods("DELETE")
+
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")
 	s.router.Handle("/user/check", c.Then(s.CheckUser())).Methods("POST")


### PR DESCRIPTION
This commit introduces an auto-reply feature for chat messages.

New API Endpoints:
- POST /chat/autoreply: Allows you to set an auto-reply message for a specific phone number. The request body requires 'Phone' and 'Body'. It stores the rule per user.
- DELETE /chat/autoreply: Allows you to remove an auto-reply rule for a specific phone number. The request body requires 'Phone'.

Core Logic:
- Database: A new 'autoreplies' table is added via migrations to store user_id, phone_number, and reply_body.
- Message Handling: Incoming messages are checked against active auto-reply rules for the recipient user and the sender's phone number. If a rule matches, the predefined reply_body is sent back.
- Loop Prevention: Auto-replies are not sent to messages originating from the bot itself (IsFromMe check).

Documentation:
- API.md and the Swagger specification (static/api/spec.yml) have been updated to include the new endpoints, request/response formats, and error codes.