### PR TITLE
feat: Implement WhatsApp autoreply feature

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -61,6 +61,7 @@ BEGIN
             user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
             phone_number TEXT NOT NULL,
             reply_body TEXT NOT NULL,
+            last_sent_at TIMESTAMP,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(user_id, phone_number)
         );
@@ -69,11 +70,12 @@ END $$;
 `
 
 const addAutorepliesTableSQLSQLite = `
-CREATE TABLE autoreplies (
+CREATE TABLE IF NOT EXISTS autoreplies (
     id TEXT PRIMARY KEY,
     user_id TEXT NOT NULL,
     phone_number TEXT NOT NULL,
     reply_body TEXT NOT NULL,
+    last_sent_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
     UNIQUE(user_id, phone_number)

--- a/routes.go
+++ b/routes.go
@@ -103,6 +103,7 @@ func (s *server) routes() {
 
 	s.router.Handle("/chat/autoreply", c.Then(s.AddAutoReply())).Methods("POST")
 	s.router.Handle("/chat/autoreply", c.Then(s.DeleteAutoReply())).Methods("DELETE")
+	s.router.Handle("/chat/autoreply", c.Then(s.GetAutoReplies())).Methods("GET")
 
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -1165,7 +1165,120 @@ paths:
             application/json:
               schema:
                 example: { "code": 200, "data": { "Details": "Participants updated successfully" }, "success": true }
+  /chat/autoreply:
+    post:
+      tags:
+        - Chat
+      summary: Add an auto-reply
+      description: Adds a new auto-reply configuration for the authenticated user.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Phone:
+                  type: string
+                  example: "1234567890"
+                Body:
+                  type: string
+                  example: "I am currently out of office."
+              required:
+                - Phone
+                - Body
+      responses:
+        "201":
+          description: Auto-reply added successfully.
+          content:
+            application/json:
+              schema:
+                example: {"code": 201, "data": {"detail": "Auto-reply added successfully", "id": "unique-id-string"}, "success": true}
+        "400":
+          description: Bad Request (e.g., missing fields).
+        "401":
+          description: Unauthorized.
+        "409":
+          description: Conflict (auto-reply for this phone number already exists).
+        "500":
+          description: Internal Server Error.
+    delete:
+      tags:
+        - Chat
+      summary: Delete an auto-reply
+      description: Deletes an auto-reply configuration based on the phone number for the authenticated user.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Phone:
+                  type: string
+                  example: "1234567890"
+              required:
+                - Phone
+      responses:
+        "200":
+          description: Auto-reply deleted successfully.
+          content:
+            application/json:
+              schema:
+                example: {"code": 200, "data": {"detail": "Auto-reply deleted successfully"}, "success": true}
+        "400":
+          description: Bad Request (e.g., missing phone number).
+        "401":
+          description: Unauthorized.
+        "404":
+          description: Auto-reply not found.
+        "500":
+          description: Internal Server Error.
+    get:
+      tags:
+        - Chat
+      summary: List configured auto-replies
+      description: Retrieves all auto-reply configurations for the authenticated user.
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: A list of auto-reply configurations.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/definitions/AutoReplyEntry'
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal Server Error
 definitions:
+  AutoReplyEntry:
+    type: object
+    properties:
+      phone:
+        type: string
+        description: "The phone number for which the auto-reply is configured."
+        example: "1234567890"
+      body:
+        type: string
+        description: "The message body of the auto-reply."
+        example: "I'm currently unavailable. I'll get back to you soon."
+      last_sent_at:
+        type: string
+        format: date-time
+        description: "The timestamp when this auto-reply was last sent. Omitted if never sent or if the value is null."
+        example: "2023-10-27T10:30:00Z"
+        nullable: true
+    required:
+      - phone
+      - body
   User:
     type: object
     properties:


### PR DESCRIPTION
This commit introduces an autoreply feature for WhatsApp messages.

Key changes:

1.  **Database Schema:**
    *   Added `last_sent_at` (TIMESTAMP) column to the `autoreplies` table to track the last time an autoreply was sent.
    *   Updated `migrations.go` to include this new column.

2.  **API Endpoints & Handlers:**
    *   Added a new `GET /chat/autoreply` endpoint to list all configured autoreplies for you.
    *   Created `GetAutoReplies` handler in `handlers.go`.
    *   Modified `AddAutoReply` in `handlers.go` to initialize `last_sent_at` to NULL.
    *   Updated `routes.go` to map the new GET endpoint.

3.  **Autoreply Logic:**
    *   Implemented the core autoreply logic in `wmiau.go` within the `myEventHandler`.
    *   When a message is received, the system checks if an autoreply rule exists for the sender.
    *   An autoreply is sent if a rule exists and if no reply has been sent to that number in the last 5 minutes.
    *   The `last_sent_at` timestamp is updated after an autoreply is sent.

4.  **API Documentation:**
    *   Updated `static/api/spec.yml` to include the new `GET /chat/autoreply` endpoint and its response schema (`AutoReplyEntry`).

This feature allows you to configure automatic replies to incoming messages with a 5-minute cooldown period per recipient.