### PR TITLE
feat: Implement autoreply modes and Google Contacts integration

### DIFF
--- a/db.go
+++ b/db.go
@@ -75,6 +75,49 @@ func createTables(db *sqlx.DB, dbType string) error {
 
 	// No initial data for active_mode as it's user-specific and populated on demand.
 
+	// Alter users table to add google_contacts_auth_token column
+	alterUsersTableSQL := ""
+	if dbType == "postgres" {
+		alterUsersTableSQL = `ALTER TABLE users ADD COLUMN IF NOT EXISTS google_contacts_auth_token TEXT;`
+	} else { // sqlite
+		// Check if column exists first for older SQLite versions.
+		// For newer SQLite (3.16.0+), ADD COLUMN is idempotent if the column exists.
+		// However, to be safe and support potentially older versions, we can check.
+		// A simpler approach for tests or if newer SQLite is guaranteed is just:
+		// alterUsersTableSQL = `ALTER TABLE users ADD COLUMN google_contacts_auth_token TEXT;`
+		// For robustness in a production-like environment, checking PRAGMA is better.
+
+		// Let's use the simpler ALTER TABLE for now, assuming modern SQLite.
+		// If this causes issues, a PRAGMA check can be added.
+		alterUsersTableSQL = `ALTER TABLE users ADD COLUMN google_contacts_auth_token TEXT;`
+
+		// Check if column exists to avoid error on re-run with older SQLite
+		var columnName string
+		query := "SELECT name FROM pragma_table_info('users') WHERE name = 'google_contacts_auth_token';"
+		err := db.Get(&columnName, query)
+		if err == nil && columnName == "google_contacts_auth_token" {
+			// Column already exists, no need to alter
+			alterUsersTableSQL = ""
+		} else if err != nil && err.Error() != "sql: no rows in result set" {
+            // An actual error occurred querying pragma_table_info
+            return fmt.Errorf("failed to check users table schema: %w", err)
+        }
+        // If err is "sql: no rows in result set", column doesn't exist, proceed with ALTER.
+	}
+
+	if alterUsersTableSQL != "" {
+		if _, err := db.Exec(alterUsersTableSQL); err != nil {
+			// For SQLite, if the column already exists, this might return an error "duplicate column name"
+			// We'll log it and continue if it's that specific error for SQLite.
+			if dbType == "sqlite" && strings.Contains(err.Error(), "duplicate column name") {
+				// log.Warn().Msg("Column google_contacts_auth_token already exists in users table (SQLite).")
+			} else {
+				return fmt.Errorf("failed to alter users table to add google_contacts_auth_token: %w", err)
+			}
+		}
+	}
+
+
 	return nil
 }
 

--- a/routes.go
+++ b/routes.go
@@ -114,6 +114,11 @@ func (s *server) routes() {
 	s.router.Handle("/mode/currentmode", c.Then(s.GetCurrentMode())).Methods("GET")
 	s.router.Handle("/mode/clear", c.Then(s.ClearModes())).Methods("POST")
 
+	// Autoreply Contact Group Routes
+	s.router.Handle("/autoreply/contactgroupauth", c.Then(s.SetGoogleContactsAuthToken())).Methods("POST")
+	s.router.Handle("/autoreply/contactgroup", c.Then(s.AddContactGroupToMode())).Methods("POST")
+	s.router.Handle("/autoreply/contactgroup", c.Then(s.DeleteContactGroupFromMode())).Methods("DELETE")
+
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")
 	s.router.Handle("/user/check", c.Then(s.CheckUser())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -1432,8 +1432,158 @@ paths:
         "500":
           description: Internal Server Error.
 
+  /autoreply/contactgroupauth:
+    post:
+      tags:
+        - Autoreply Contacts
+      summary: Store Google Contacts API Auth Token
+      description: Stores or updates the Google OAuth2 access token for the authenticated user, enabling integration with Google Contacts.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/AuthTokenRequest'
+      responses:
+        "200":
+          description: Auth token stored successfully.
+          content:
+            application/json:
+              schema:
+                example: {"code": 200, "data": {"detail": "Auth token stored successfully"}, "success": true}
+        "400":
+          description: Bad Request (e.g., missing AuthToken).
+          content:
+            application/json:
+              schema:
+                example: {"code": 400, "error": "Missing AuthToken in Payload", "success": false}
+        "500":
+          description: Internal Server Error.
+
+  /autoreply/contactgroup:
+    post:
+      tags:
+        - Autoreply Contacts
+      summary: Add contacts from a Google Contacts group to an autoreply mode
+      description: Fetches contacts from a specified Google Contacts group (using a stored auth token) and adds/updates them in the specified autoreply mode with the given message.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/ContactGroupRequest'
+      responses:
+        "200":
+          description: Contacts processed and added/updated for the mode.
+          content:
+            application/json:
+              schema:
+                example: {"code": 200, "data": {"detail": "3 contacts processed and added/updated for mode 'work'. 1 contacts skipped."}, "success": true}
+        "400":
+          description: Bad Request (e.g., missing fields, invalid ModeName).
+        "403":
+          description: Forbidden (Google Contacts API token not configured).
+          content:
+            application/json:
+              schema:
+                example: {"code": 403, "error": "Google Contacts API token not configured. Please use /autoreply/contactgroupauth.", "success": false}
+        "500":
+          description: Internal Server Error.
+    delete:
+      tags:
+        - Autoreply Contacts
+      summary: Remove contacts from a Google Contacts group from an autoreply mode
+      description: Fetches contacts from a specified Google Contacts group (using a stored auth token) and removes them from the specified autoreply mode.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/ContactGroupDeleteRequest'
+      responses:
+        "200":
+          description: Contacts processed for deletion from the mode.
+          content:
+            application/json:
+              schema:
+                example: {"code": 200, "data": {"detail": "3 contacts from group 'Friends' processed for deletion from mode 'weekend'. 2 entries actually deleted. 1 contacts skipped."}, "success": true}
+        "400":
+          description: Bad Request (e.g., missing fields, invalid ModeName).
+        "403":
+          description: Forbidden (Google Contacts API token not configured).
+        "500":
+          description: Internal Server Error.
+
 definitions:
-  ModeAutoreplyRequest:
+  AuthTokenRequest:
+    type: object
+    required:
+      - AuthToken
+    properties:
+      AuthToken:
+        type: string
+        description: "User-provided Google OAuth2 Access Token."
+        example: "ya29.a0AfH6SM..."
+  AutoReplyEntry: # Existing definition, ensure new ones are placed correctly relative to it.
+    type: object
+    properties:
+      phone:
+        type: string
+        description: "The phone number for which the auto-reply is configured."
+        example: "1234567890"
+      body:
+        type: string
+        description: "The message body of the auto-reply."
+        example: "I'm currently unavailable. I'll get back to you soon."
+      last_sent_at:
+        type: string
+        format: date-time
+        description: "The timestamp when this auto-reply was last sent. Omitted if never sent or if the value is null."
+        example: "2023-10-27T10:30:00Z"
+        nullable: true
+    required:
+      - phone
+      - body
+  ContactGroupDeleteRequest:
+    type: object
+    required:
+      - ModeName
+      - GroupName
+    properties:
+      ModeName:
+        type: string
+        description: "Name of the mode (alphanumeric)."
+        example: "work"
+      GroupName:
+        type: string
+        description: "Name of the Google Contacts group whose members will be removed from the mode."
+        example: "Old Colleagues"
+  ContactGroupRequest:
+    type: object
+    required:
+      - ModeName
+      - GroupName
+      - Message
+    properties:
+      ModeName:
+        type: string
+        description: "Name of the mode to associate contacts with (alphanumeric)."
+        example: "work"
+      GroupName:
+        type: string
+        description: "Name of the Google Contacts group to fetch contacts from."
+        example: "Colleagues"
+      Message:
+        type: string
+        description: "Autoreply message for these contacts within the specified mode."
+        example: "Currently busy with work tasks."
+  ModeAutoreplyRequest: # Existing definition
     type: object
     required:
       - ModeName


### PR DESCRIPTION
This commit introduces a comprehensive autoreply mode management system and integrates with Google Contacts for populating modes.

Key features:

1.  **Autoreply Modes Management (Phase 1):**
    *   New `autoreply_modes` table to store mode configurations (mode name, phone number, message) per user.
    *   New `active_mode` table to track the currently active mode per user.
    *   API Endpoints:
        *   `POST /mode/autoreply`: Add/update a phone number and message to a mode.
        *   `DELETE /mode/autoreply`: Delete a phone number from a mode or an entire mode.
        *   `GET /mode/autoreply`: List configured autoreplies for a mode or all modes.
        *   `POST /mode/enablemode`: Activate a mode, loading its numbers into the live autoreply list.
        *   `POST /mode/disablemode`: Deactivate the current mode.
        *   `GET /mode/currentmode`: View the currently active mode.
        *   `POST /mode/clear`: Clear all active autoreplies.
    *   Mode names are stored in lowercase and validated (alphanumeric).
    *   Comprehensive unit tests for all mode management handlers.
    *   OpenAPI specification updated for all new mode endpoints.

2.  **Google Contacts Integration (Phase 2):**
    *   `users` table updated with `google_contacts_auth_token` column to store user-provided OAuth tokens.
    *   API Endpoints:
        *   `POST /autoreply/contactgroupauth`: Store Google Contacts API auth token for you.
        *   `POST /autoreply/contactgroup`: Fetch contacts from a (mocked) Google Contacts group using the stored token, normalize phone numbers, and add them to a specified autoreply mode.
        *   `DELETE /autoreply/contactgroup`: Fetch contacts from a (mocked) Google Contacts group, normalize phone numbers, and remove them from a specified autoreply mode.
    *   Implemented robust phone number normalization logic (handles '+' prefix, default country code '91').
    *   Google Contacts API interaction is currently via a placeholder function (`fetchContactsFromGoogleGroup`) to allow testing of the surrounding logic.
    *   Unit tests for new handlers, including token management, phone normalization, and mocked API interaction.
    *   OpenAPI specification updated for Google Contacts integration endpoints.

All database schema changes are handled idempotently. All new endpoints are covered by authentication middleware.