### PR TITLE
fix: Add missing strings import to db.go

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings" // Added this line
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"


### PR DESCRIPTION
The db.go file used strings.Contains without importing the "strings" package, leading to an "undefined: strings" compilation error.

This commit adds "strings" to the import block in db.go to resolve the issue.