### PR TITLE
feat: Implement live Google Contacts fetching for autoreply modes

### DIFF
--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -8,6 +8,26 @@ info:
 schemes:
   - http
 
+tags:
+  - name: Admin
+    description: Operations for user administration
+  - name: Session
+    description: Manage WhatsApp connection sessions (connect, disconnect, status, QR)
+  - name: Webhook
+    description: Configure and manage webhooks for incoming messages and events
+  - name: User
+    description: User-related operations (info, check, presence, avatar, contacts)
+  - name: Chat
+    description: Operations for sending and managing messages (text, media, autoreply)
+  - name: Mode
+    description: Manage autoreply modes
+  - name: Autoreply Contacts
+    description: Manage autoreply settings using Google Contacts integration
+  - name: Group
+    description: Operations related to WhatsApp groups
+  - name: Newsletter
+    description: Operations related to WhatsApp newsletters
+
 paths:
   /admin/users:
     get:


### PR DESCRIPTION
This commit replaces the placeholder implementation of `fetchContactsFromGoogleGroup` with live HTTP calls to the Google People API.

Key changes:
- `fetchContactsFromGoogleGroup` now:
  - Fetches all contact groups for the authenticated user to find the `resourceName` of the target group by its display name.
  - Fetches all connections (contacts) for `people/me`, requesting names, phone numbers, and memberships.
  - Filters connections to find members of the target group.
  - Extracts names and phone numbers of group members.
  - Handles pagination for API calls.
  - Includes the OAuth2 token in `Authorization: Bearer` headers.
  - Defines structs for parsing Google People API JSON responses.
- Enhanced error handling:
  - `fetchContactsFromGoogleGroup` attempts to parse Google's JSON error responses to return more specific error messages.
  - Calling handlers (`AddContactGroupToMode`, `DeleteContactGroupFromMode`) inspect these errors to return appropriate HTTP status codes (403, 404, 500) and user-friendly messages.
  - Improved handling of cases where no contacts are found in a group.
- Unit tests in `handlers_mode_test.go` updated:
  - `fetchContactsFromGoogleGroupFunc` is now a package-level variable, allowing it to be mocked effectively during tests.
  - Tests now cover the new error handling paths and ensure correct handler behavior based on various (mocked) outcomes from `fetchContactsFromGoogleGroupFunc`.