### PR TITLE
refactor: Standardize autoreply URLs and Swagger tags

### DIFF
--- a/handlers_mode_test.go
+++ b/handlers_mode_test.go
@@ -273,7 +273,7 @@ func TestAddModeAutoreply(t *testing.T) {
 			if tc.name == "Update existing mode message" {
 				setupPayload := ModeAutoreplyRequest{ModeName: "Work", Phone: "111222333", Message: "Initial message"}
 				jsonBody, _ := json.Marshal(setupPayload)
-				req := newAuthenticatedRequest(t, "POST", "/mode/autoreply", bytes.NewBuffer(jsonBody), testUserToken1, testUserID1)
+				req := newAuthenticatedRequest(t, "POST", "/autoreply/mode", bytes.NewBuffer(jsonBody), testUserToken1, testUserID1)
 				rr := httptest.NewRecorder()
 				testRouter.ServeHTTP(rr, req) // Use testRouter directly
 				require.Equal(t, http.StatusCreated, rr.Code)
@@ -283,7 +283,7 @@ func TestAddModeAutoreply(t *testing.T) {
 			jsonBody, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
 
-			req := newAuthenticatedRequest(t, "POST", "/mode/autoreply", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "POST", "/autoreply/mode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -385,7 +385,7 @@ func TestDeleteModeAutoreply(t *testing.T) {
 			jsonBody, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
 
-			req := newAuthenticatedRequest(t, "DELETE", "/mode/autoreply", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "DELETE", "/autoreply/mode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -493,7 +493,7 @@ func TestGetModeAutoreplies(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			req := newAuthenticatedRequest(t, "GET", "/mode/autoreply"+tc.modeNameQuery, nil, tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "GET", "/autoreply/mode"+tc.modeNameQuery, nil, tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -654,7 +654,7 @@ func TestEnableMode(t *testing.T) {
 			jsonBody, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
 
-			req := newAuthenticatedRequest(t, "POST", "/mode/enablemode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "POST", "/autoreply/enablemode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -747,7 +747,7 @@ func TestDisableMode(t *testing.T) {
 			jsonBody, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
 
-			req := newAuthenticatedRequest(t, "POST", "/mode/disablemode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "POST", "/autoreply/disablemode", bytes.NewBuffer(jsonBody), tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -812,7 +812,7 @@ func TestGetCurrentMode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			req := newAuthenticatedRequest(t, "GET", "/mode/currentmode", nil, tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "GET", "/autoreply/currentmode", nil, tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 
@@ -890,7 +890,7 @@ func TestClearModes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			req := newAuthenticatedRequest(t, "POST", "/mode/clear", nil, tc.userToken, tc.userID)
+			req := newAuthenticatedRequest(t, "POST", "/autoreply/clearmode", nil, tc.userToken, tc.userID)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, req)
 

--- a/routes.go
+++ b/routes.go
@@ -105,14 +105,14 @@ func (s *server) routes() {
 	s.router.Handle("/chat/autoreply", c.Then(s.DeleteAutoReply())).Methods("DELETE")
 	s.router.Handle("/chat/autoreply", c.Then(s.GetAutoReplies())).Methods("GET")
 
-	// Mode Autoreply Routes
-	s.router.Handle("/mode/autoreply", c.Then(s.AddModeAutoreply())).Methods("POST")
-	s.router.Handle("/mode/autoreply", c.Then(s.DeleteModeAutoreply())).Methods("DELETE")
-	s.router.Handle("/mode/autoreply", c.Then(s.GetModeAutoreplies())).Methods("GET")
-	s.router.Handle("/mode/enablemode", c.Then(s.EnableMode())).Methods("POST")
-	s.router.Handle("/mode/disablemode", c.Then(s.DisableMode())).Methods("POST")
-	s.router.Handle("/mode/currentmode", c.Then(s.GetCurrentMode())).Methods("GET")
-	s.router.Handle("/mode/clear", c.Then(s.ClearModes())).Methods("POST")
+	// Autoreply Mode Routes (formerly /mode/)
+	s.router.Handle("/autoreply/mode", c.Then(s.AddModeAutoreply())).Methods("POST")
+	s.router.Handle("/autoreply/mode", c.Then(s.DeleteModeAutoreply())).Methods("DELETE")
+	s.router.Handle("/autoreply/mode", c.Then(s.GetModeAutoreplies())).Methods("GET")
+	s.router.Handle("/autoreply/enablemode", c.Then(s.EnableMode())).Methods("POST")
+	s.router.Handle("/autoreply/disablemode", c.Then(s.DisableMode())).Methods("POST")
+	s.router.Handle("/autoreply/currentmode", c.Then(s.GetCurrentMode())).Methods("GET")
+	s.router.Handle("/autoreply/clearmode", c.Then(s.ClearModes())).Methods("POST")
 
 	// Autoreply Contact Group Routes
 	s.router.Handle("/autoreply/contactgroupauth", c.Then(s.SetGoogleContactsAuthToken())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -18,11 +18,9 @@ tags:
   - name: User
     description: User-related operations (info, check, presence, avatar, contacts)
   - name: Chat
-    description: Operations for sending and managing messages (text, media, autoreply)
-  - name: Mode
-    description: Manage autoreply modes
-  - name: Autoreply Contacts
-    description: Manage autoreply settings using Google Contacts integration
+    description: Operations for sending and managing messages (text, media)
+  - name: Autoreply
+    description: Operations related to autoreply configuration, modes, and contact group integration.
   - name: Group
     description: Operations related to WhatsApp groups
   - name: Newsletter
@@ -1188,7 +1186,7 @@ paths:
   /chat/autoreply:
     post:
       tags:
-        - Chat
+        - Autoreply
       summary: Add an auto-reply
       description: Adds a new auto-reply configuration for the authenticated user.
       security:
@@ -1226,7 +1224,7 @@ paths:
           description: Internal Server Error.
     delete:
       tags:
-        - Chat
+        - Autoreply
       summary: Delete an auto-reply
       description: Deletes an auto-reply configuration based on the phone number for the authenticated user.
       security:
@@ -1260,7 +1258,7 @@ paths:
           description: Internal Server Error.
     get:
       tags:
-        - Chat
+        - Autoreply
       summary: List configured auto-replies
       description: Retrieves all auto-reply configurations for the authenticated user.
       security:
@@ -1279,10 +1277,10 @@ paths:
         "500":
           description: Internal Server Error
 
-  /mode/autoreply:
+  /autoreply/mode:
     post:
       tags:
-        - Mode
+        - Autoreply
       summary: Add or Update Mode Autoreply
       description: Adds a new autoreply entry for a specific mode or updates an existing one (based on ModeName and Phone).
       security:
@@ -1310,7 +1308,7 @@ paths:
           description: Internal Server Error.
     delete:
       tags:
-        - Mode
+        - Autoreply
       summary: Delete Mode Autoreply
       description: Deletes autoreply entries for a specific mode. If 'Phone' is provided, only that specific entry is deleted. Otherwise, all entries for the mode are deleted.
       security:
@@ -1334,7 +1332,7 @@ paths:
           description: Internal Server Error.
     get:
       tags:
-        - Mode
+        - Autoreply
       summary: Get Mode Autoreplies
       description: Retrieves autoreply entries. If 'modeName' query parameter is provided, filters by that mode. Otherwise, retrieves all mode autoreplies for the user.
       security:
@@ -1362,10 +1360,10 @@ paths:
         "500":
           description: Internal Server Error.
 
-  /mode/enablemode:
+  /autoreply/enablemode:
     post:
       tags:
-        - Mode
+        - Autoreply
       summary: Enable an Autoreply Mode
       description: Activates a specific autoreply mode. This clears any existing active autoreplies and populates them with entries from the specified mode.
       security:
@@ -1390,10 +1388,10 @@ paths:
         "500":
           description: Internal Server Error.
 
-  /mode/disablemode:
+  /autoreply/disablemode:
     post:
       tags:
-        - Mode
+        - Autoreply
       summary: Disable an Autoreply Mode
       description: Deactivates the specified autoreply mode if it is currently active. This clears active autoreplies and sets the current mode to none.
       security:
@@ -1416,10 +1414,10 @@ paths:
         "500":
           description: Internal Server Error.
 
-  /mode/currentmode:
+  /autoreply/currentmode:
     get:
       tags:
-        - Mode
+        - Autoreply
       summary: Get Current Active Autoreply Mode
       description: Retrieves the name of the currently active autoreply mode for the user.
       security:
@@ -1434,10 +1432,10 @@ paths:
         "500":
           description: Internal Server Error.
 
-  /mode/clear:
+  /autoreply/clearmode:
     post:
       tags:
-        - Mode
+        - Autoreply
       summary: Clear All Autoreply Modes
       description: Deactivates any currently active autoreply mode and clears all entries from the active autoreply list for the user. It does not delete entries from `autoreply_modes`.
       security:
@@ -1455,7 +1453,7 @@ paths:
   /autoreply/contactgroupauth:
     post:
       tags:
-        - Autoreply Contacts
+        - Autoreply
       summary: Store Google Contacts API Auth Token
       description: Stores or updates the Google OAuth2 access token for the authenticated user, enabling integration with Google Contacts.
       security:
@@ -1485,7 +1483,7 @@ paths:
   /autoreply/contactgroup:
     post:
       tags:
-        - Autoreply Contacts
+        - Autoreply
       summary: Add contacts from a Google Contacts group to an autoreply mode
       description: Fetches contacts from a specified Google Contacts group (using a stored auth token) and adds/updates them in the specified autoreply mode with the given message.
       security:
@@ -1515,7 +1513,7 @@ paths:
           description: Internal Server Error.
     delete:
       tags:
-        - Autoreply Contacts
+        - Autoreply
       summary: Remove contacts from a Google Contacts group from an autoreply mode
       description: Fetches contacts from a specified Google Contacts group (using a stored auth token) and removes them from the specified autoreply mode.
       security:


### PR DESCRIPTION
This commit refactors the API paths for mode management and consolidates Swagger tags for all autoreply-related features.

Changes:
- **URL Refactoring:**
  - `/mode/autoreply` (POST, GET, DELETE) moved to `/autoreply/mode`.
  - `/mode/enablemode` moved to `/autoreply/enablemode`.
  - `/mode/disablemode` moved to `/autoreply/disablemode`.
  - `/mode/currentmode` moved to `/autoreply/currentmode`.
  - `/mode/clear` moved to `/autoreply/clearmode`. These changes are reflected in `routes.go`.

- **Swagger Spec Updates (`static/api/spec.yml`):**
  - Paths updated to match the new URL structure.
  - Removed `Mode` and `Autoreply Contacts` global tag definitions.
  - Added/updated a single `Autoreply` global tag.
  - All mode management endpoints (now under `/autoreply/...`), Google Contacts integration endpoints (`/autoreply/contactgroup...`), and simple autoreply endpoints (`/chat/autoreply...`) are now grouped under the `Autoreply` tag in Swagger.

- **Unit Tests:**
  - Endpoint URLs in `handlers_mode_test.go` updated to match the new `/autoreply/...` paths.