### PR TITLE
fix: Add missing io import to handlers.go

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"io" // Added this line
 	"net/http"
 	"net/url"
 	"os"


### PR DESCRIPTION
The handlers.go file used io.ReadAll without importing the "io" package, specifically within the fetchContactsFromGoogleGroupFunc when handling HTTP error responses from the Google People API. This caused an "undefined: io" compilation error.

This commit adds "io" to the import block in handlers.go to resolve the issue.