### PR TITLE
refactor: Remove unused strings import from db.go

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings" // Added this line
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"


### PR DESCRIPTION
The "strings" package was previously imported in db.go to support `strings.Contains` for conditional ALTER TABLE logic for SQLite. This logic has since been moved into the migrations system (`migrations.go`).

As a result, the "strings" import is no longer used in `db.go` and has been removed to prevent "imported and not used" build errors.