### PR TITLE
I've addressed an issue in the migrations.go file. It was using `log.…

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	log "github.com/rs/zerolog/log" // Added this line
 )
 
 type Migration struct {


### PR DESCRIPTION
…Info()` without the necessary import for the logging package ("github.com/rs/zerolog/log"), which led to an "undefined: log" compilation error. I've now added the "log" import to migrations.go to fix this.